### PR TITLE
Problem: There is no introductory text in the Readme.md of the project.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
-# dql-language-specification
-The specification of the DQL language.
+
+# The Domain Query Language (DQL) - Specification
+
+## Welcome
+
+The Domain Query Language (DQL) is a domain-specific language for creating, reshaping and maintaining the business logic of one or more domains. At it's core, it uses the tactical Domain Driven Design (DDD), Command-Query Responsibility Segregation (CQRS) and Event Sourcing (ES) design patterns.
+
+## License
+
+MIT License
+
+Copyright (c) 2016 Colin Lyons
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. 


### PR DESCRIPTION
Solution: Refactored the Readme.md file with one or two sentences about the project, also making the License of the project front and centre.
